### PR TITLE
Zenodo release process

### DIFF
--- a/.github/workflows/zenodo-upload.yml
+++ b/.github/workflows/zenodo-upload.yml
@@ -1,0 +1,78 @@
+name: zenodo-upload
+
+on:
+  release:
+  workflow_dispatch:
+
+jobs:
+
+  bundles:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v5
+      with:
+        submodules: 'true'
+        path: 'crabook-src-${{ github.ref_name }}'
+
+    # Leave out version name from archive so files from previous record on
+    # Zenodo are replaced when uploading.
+    - name: Create src bundle
+      run: zip -r crabook-src.zip 'crabook-src-${{ github.ref_name }}' -x '*/.git/*'
+
+    # Create artifacts to provide a manual fallback for when the upload fails.
+    # When downloading this bundle, there will be an archive inside an archive.
+    - name: Create src bundle artifact
+      uses: actions/upload-artifact@v5
+      with:
+        name: crabook-src
+        path: crabook-src.zip
+
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
+
+    - name: Install dependencies
+      run: pip install -r 'crabook-src-${{ github.ref_name }}/requirements.txt'
+
+    # Remove the sources from the html to reduce size and avoid duplication.
+    - name: Build the Handbook
+      run: |
+        cd 'crabook-src-${{ github.ref_name }}'
+        jb build crabook
+        rm -r crabook/_build/html/_sources
+        mv crabook/_build/html '../crabook-html-${{ github.ref_name }}'
+
+    # As above, only put the version number inside the archive.
+    - name: Create html bundle
+      run: zip -r crabook-html.zip 'crabook-html-${{ github.ref_name }}'
+
+    # As above, archive within an archive on download for manual fallback.
+    - name: Create html bundle artifact
+      uses: actions/upload-artifact@v5
+      with:
+        name: crabook-html
+        path: crabook-html.zip
+
+  record:
+    runs-on: ubuntu-latest
+    needs: bundles
+    steps:
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
+
+    - name: Install openscm-zenodo
+      run: pip install openscm-zenodo
+
+    # Get the crabook-src and crabook-html archives from above
+    - uses: actions/download-artifact@v7
+
+    # Create a new draft version on Zenodo and replace the existing files with
+    # the ones built above. openscm-zenodo will keep the metadata from the
+    # existing record for the new draft version. The draft has to be finalised
+    # via the Zenodo web interface due to missing functionality in the API that
+    # we need to fill all metadata (dual license, multiple affiliations) and
+    # because the metadata updates via the API are all-or-nothing (see PR #23).
+    - name: Create a new draft version on Zenodo
+      run: openscm-zenodo create-new-version --zenodo-domain "https://zenodo.org" --token "${{ secrets.ZENODO_TOKEN }}" --n-threads 1 18196375 crabook-src/crabook-src.zip crabook-html/crabook-html.zip

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jb clean crabook
 
 1. Tag all submodule repositories that have changed since the last release.
 2. Tag the Handbook and create a release from the tag. Provide release notes for changes from all repositories.
-3. The zenodo-upload action creates a new Zenodo version draft. Go to Zenodo, check the file contents, update the list of contributors if necessary, fill in the publication date and version number and publish.
+3. The zenodo-upload action creates a new Zenodo version draft. [Go to Zenodo](https://zenodo.org/records/18196375), enter the new version dialogue, check the file contents, update the list of contributors if necessary, fill in the publication date, and the version number and publish.
 4. Announce the new release on the Handbook discussion forum.
 
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ To remove existing builds:
 jb clean crabook
 ```
 
+### Release process
+
+1. Tag all submodule repositories that have changed since the last release.
+2. Tag the Handbook and create a release from the tag. Provide release notes for changes from all repositories.
+3. The zenodo-upload action creates a new Zenodo version draft. Go to Zenodo, check the file contents, update the list of contributors if necessary, fill in the publication date and version number and publish.
+4. Announce the new release on the Handbook discussion forum.
+
 
 ## License
 


### PR DESCRIPTION
- [x] Set up zenodo-upload action triggered on release
- [x] Document release process

### Background: Why not a fully automated release process for Zenodo?

Our metadata contains authors with multiple affiliations and the Handbook is dual-licensed. Zenodo does not support setting either of these fields to multiple values through the API at present:

- https://github.com/zenodo/zenodo/issues/1608
- https://github.com/zenodo/zenodo/issues/2515

This isn't an issue if we could transfer the Zenodo metadata from the current version to a new version and only update the metadata selectively but, as far as I can tell, metadata updates via the API are all-or-nothing. It's not possible to update individual fields of a new draft version without resetting all other fields to their default value. So the choices are to

1. not update any metadata so the old metadata is preserved, then manually update fields via the Zenodo website,
2. update the metadata, then manually fix the fields where API limitations exist via the Zenodo website,
3. update the metadata and live with some "broken" entries.

I don't like option 3 and 2 seems worse in terms of effort than 1, especially since all manual edits in 1 are actually related to the release (version number, publication date). A disadvantage of 2 is that if we want to keep a list of contributors in the Handbook repository, we have to maintain it in addition to the Zenodo list with no automatic sync.

Given our frequency of releases, some of manual intervention is acceptable at present. This PR implements option 1. The automated action only creates a new draft version on Zenodo and populates it with files (the part that takes effort) but doesn't update the metadata (the metadata from the previous record is retained). The version must then be finalised and published manually via the Zenodo web interface.